### PR TITLE
Update tenant status column default value and remove redundant migration

### DIFF
--- a/supabase/migrations/20251213143152_add_tenant_status_subscription.sql
+++ b/supabase/migrations/20251213143152_add_tenant_status_subscription.sql
@@ -5,7 +5,7 @@
 CREATE TYPE tenant.tenant_status AS ENUM ('active', 'suspended', 'trial', 'inactive');
 
 ALTER TABLE tenant.tenants 
-  ADD COLUMN IF NOT EXISTS status tenant.tenant_status DEFAULT 'trial' NOT NULL;
+  ADD COLUMN IF NOT EXISTS status tenant.tenant_status DEFAULT 'active' NOT NULL;
 
 -- Add subscription column with enum type  
 CREATE TYPE tenant.subscription_tier AS ENUM ('starter', 'pro', 'enterprise');

--- a/supabase/migrations/20251227000004_add_tenant_status.sql
+++ b/supabase/migrations/20251227000004_add_tenant_status.sql
@@ -1,3 +1,0 @@
--- Add status column to tenant.tenants
-CREATE TYPE tenant.tenant_status AS ENUM ('active', 'trial', 'inactive', 'suspended');
-ALTER TABLE tenant.tenants ADD COLUMN IF NOT EXISTS status tenant.tenant_status DEFAULT 'active';


### PR DESCRIPTION
This pull request updates the database schema related to tenant status in the `tenant.tenants` table. The main changes include modifying the default value for the `status` column and removing a redundant migration that previously introduced the same column and enum type.

**Database schema updates:**

* Changed the default value of the `status` column in `tenant.tenants` from `'trial'` to `'active'` in the migration file `20251213143152_add_tenant_status_subscription.sql`.
* Removed the redundant migration file `20251227000004_add_tenant_status.sql`, which previously added the `tenant_status` enum type and the `status` column.