### PR TITLE
Rename Ready for Payment to Ready for Delivery

### DIFF
--- a/src/components/tenant/jobs/job-details-dialog.tsx
+++ b/src/components/tenant/jobs/job-details-dialog.tsx
@@ -336,7 +336,7 @@ export function JobDetailsDialog({
                       Invoice
                       {job.status !== "ready" && job.status !== "completed" && (
                         <span className="ml-2 text-xs text-muted-foreground">
-                          (Available when Ready for Payment)
+                          (Available when Ready for Delivery)
                         </span>
                       )}
                     </TabsTrigger>

--- a/src/components/tenant/views/jobs-board-view.tsx
+++ b/src/components/tenant/views/jobs-board-view.tsx
@@ -51,7 +51,7 @@ interface JobBoardProps {
 const COLUMNS: { id: JobStatus; label: string }[] = [
   { id: "received", label: "Received" },
   { id: "working", label: "Working" },
-  { id: "ready", label: "Ready for Payment" },
+  { id: "ready", label: "Ready for Delivery" },
   { id: "completed", label: "Completed" },
 ];
 

--- a/src/modules/job/domain/job.entity.ts
+++ b/src/modules/job/domain/job.entity.ts
@@ -60,7 +60,7 @@ export const statusConfig: Record<JobStatus, StatusConfigItem> = {
     bgColor: 'bg-amber-500/20',
   },
   ready: {
-    label: 'Ready for Payment',
+    label: 'Ready for Delivery',
     color: 'text-emerald-400',
     bgColor: 'bg-emerald-500/20',
   },


### PR DESCRIPTION
Renamed the "Ready for Payment" job status to "Ready for Delivery" to better reflect the workflow where delivery happens before final completion/payment finalization.

Changes:
- `src/modules/job/domain/job.entity.ts`: Updated `statusConfig` label.
- `src/components/tenant/views/jobs-board-view.tsx`: Updated Kanban column header.
- `src/components/tenant/jobs/job-details-dialog.tsx`: Updated helper text for Invoice tab availability.

---
*PR created automatically by Jules for task [1414152757395197805](https://jules.google.com/task/1414152757395197805) started by @sagun-py0909*