### PR TITLE
Fix exposure of transaction ID closes #178

### DIFF
--- a/src/app/(tenant)/inventory/page.tsx
+++ b/src/app/(tenant)/inventory/page.tsx
@@ -31,7 +31,6 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } f
 import { toast } from "sonner";
 
 interface AllocationWithRelations {
-  id: string;
   itemId: string;
   itemName: string;
   jobcardId: string;
@@ -45,13 +44,11 @@ interface AllocationWithRelations {
 }
 
 interface TransactionWithItem {
-  id: string;
   itemId: string;
   itemName?: string;
   transactionType: string;
   quantity: number;
   referenceType?: string;
-  referenceId?: string;
   createdAt: string;
 }
 
@@ -409,8 +406,8 @@ export default function InventoryPage() {
                       </TableCell>
                     </TableRow>
                   ) : (
-                    reservedAllocations.map((allocation) => (
-                      <TableRow key={allocation.id}>
+                    reservedAllocations.map((allocation, index) => (
+                      <TableRow key={`${allocation.itemId}-${allocation.jobcardId}-${index}`}>
                         <TableCell className="font-medium">{allocation.itemName}</TableCell>
                         <TableCell>
                           <Badge variant="outline">{allocation.jobNumber}</Badge>
@@ -471,8 +468,8 @@ export default function InventoryPage() {
                       </TableCell>
                     </TableRow>
                   ) : (
-                    recentTransactions.map((tx) => (
-                      <TableRow key={tx.id}>
+                    recentTransactions.map((tx, index) => (
+                      <TableRow key={`${tx.itemId}-${tx.createdAt}-${index}`}>
                         <TableCell className="font-medium">{tx.itemName || 'Unknown'}</TableCell>
                         <TableCell>
                           <Badge variant={getTransactionBadgeVariant(tx.transactionType)}>

--- a/src/app/(tenant)/inventory/page.tsx
+++ b/src/app/(tenant)/inventory/page.tsx
@@ -468,8 +468,8 @@ export default function InventoryPage() {
                       </TableCell>
                     </TableRow>
                   ) : (
-                    recentTransactions.map((tx, index) => (
-                      <TableRow key={`${tx.itemId}-${tx.createdAt}-${index}`}>
+                    recentTransactions.map((tx) => (
+                      <TableRow key={`${tx.itemId}-${tx.createdAt}-${tx.transactionType}-${tx.quantity}`}>
                         <TableCell className="font-medium">{tx.itemName || 'Unknown'}</TableCell>
                         <TableCell>
                           <Badge variant={getTransactionBadgeVariant(tx.transactionType)}>

--- a/src/app/(tenant)/inventory/page.tsx
+++ b/src/app/(tenant)/inventory/page.tsx
@@ -407,7 +407,7 @@ export default function InventoryPage() {
                     </TableRow>
                   ) : (
                     reservedAllocations.map((allocation, index) => (
-                      <TableRow key={`${allocation.itemId}-${allocation.jobcardId}-${index}`}>
+                      <TableRow key={`${allocation.itemId}-${allocation.jobcardId}-${allocation.reservedAt}`}>
                         <TableCell className="font-medium">{allocation.itemName}</TableCell>
                         <TableCell>
                           <Badge variant="outline">{allocation.jobNumber}</Badge>

--- a/src/app/api/inventory/allocations/consume/route.ts
+++ b/src/app/api/inventory/allocations/consume/route.ts
@@ -37,7 +37,7 @@ export async function POST(request: Request) {
     const { allocationId, jobcardId, itemId, quantity } = result.data
 
     const service = createInventoryAllocationService(supabase, tenantId)
-    
+
     let consumeResult
     if (allocationId) {
       consumeResult = await service.consumeAllocation(allocationId, quantity, userId)
@@ -49,14 +49,12 @@ export async function POST(request: Request) {
 
     return NextResponse.json({
       success: true,
-      allocationId: consumeResult.allocation.id,
       quantityConsumed: consumeResult.quantityConsumed,
-      transactionId: consumeResult.transactionId,
     })
 
   } catch (error: unknown) {
     console.error('Error consuming stock:', error)
-    
+
     if (error instanceof AllocationNotFoundError) {
       return NextResponse.json({
         error: error.message,

--- a/src/app/api/inventory/allocations/release/route.ts
+++ b/src/app/api/inventory/allocations/release/route.ts
@@ -52,11 +52,6 @@ export async function POST(request: Request) {
       success: true,
       releasedCount: releaseResult.releasedAllocations.length,
       totalQuantityReleased: releaseResult.totalQuantityReleased,
-      releasedAllocations: releaseResult.releasedAllocations.map(a => ({
-        id: a.id,
-        itemId: a.itemId,
-        quantityReleased: a.quantityReserved,
-      })),
     })
 
   } catch (error: unknown) {

--- a/src/app/api/inventory/allocations/reserve/route.ts
+++ b/src/app/api/inventory/allocations/reserve/route.ts
@@ -44,8 +44,6 @@ export async function POST(request: Request) {
     )
 
     return NextResponse.json({
-      allocationId: reserveResult.allocation.id,
-      itemId: reserveResult.allocation.itemId,
       quantityReserved: reserveResult.allocation.quantityReserved,
       stockRemaining: reserveResult.stockRemaining,
       stockAvailable: reserveResult.stockAvailable,

--- a/src/app/api/inventory/allocations/route.ts
+++ b/src/app/api/inventory/allocations/route.ts
@@ -31,13 +31,13 @@ export async function GET(request: Request) {
     const limit = searchParams.get('limit')
 
     const repository = new SupabaseAllocationRepository(supabase, tenantId)
-    
+
     // If with_relations is true, use the new method
     if (withRelations) {
       const statusFilter = status && isValidAllocationStatus(status) ? status : undefined
       const limitNum = limit ? parseInt(limit, 10) : 50
       const allocations = await repository.findWithRelations(statusFilter, limitNum)
-      return NextResponse.json(allocations)
+      return NextResponse.json(allocations.map(({ id, ...rest }: any) => rest))
     }
 
     let allocations
@@ -52,7 +52,7 @@ export async function GET(request: Request) {
       allocations = await repository.findByStatus('reserved')
     }
 
-    return NextResponse.json(allocations)
+    return NextResponse.json(allocations.map(({ id, tenantId, ...rest }: any) => rest))
   } catch (error: unknown) {
     console.error('Error fetching allocations:', error)
     return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 })

--- a/src/components/inventory/TransactionHistory.tsx
+++ b/src/components/inventory/TransactionHistory.tsx
@@ -11,15 +11,25 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { InventoryTransaction } from "@/modules/inventory/domain/inventory.entity";
 import { Badge } from "@/components/ui/badge";
+
+/** Client-safe transaction shape (no raw DB IDs) */
+interface SafeTransaction {
+  itemId: string;
+  transactionType: string;
+  quantity: number;
+  unitCost?: number;
+  referenceType?: string;
+  createdBy?: string;
+  createdAt: string;
+}
 
 interface TransactionHistoryProps {
   itemId?: string;
 }
 
 export function TransactionHistory({ itemId }: TransactionHistoryProps) {
-  const [transactions, setTransactions] = useState<InventoryTransaction[]>([]);
+  const [transactions, setTransactions] = useState<SafeTransaction[]>([]);
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
@@ -65,8 +75,8 @@ export function TransactionHistory({ itemId }: TransactionHistoryProps) {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {transactions.map((tx) => (
-                <TableRow key={tx.id}>
+              {transactions.map((tx, index) => (
+                <TableRow key={`${tx.itemId}-${tx.createdAt}-${index}`}>
                   <TableCell>{format(new Date(tx.createdAt), "MMM d, yyyy HH:mm")}</TableCell>
                   <TableCell>
                     <Badge variant="outline" className="capitalize">


### PR DESCRIPTION
This pull request refactors the inventory and transaction API responses and UI components to remove internal database identifiers (such as `id`, `tenantId`, and `referenceId`) from data sent to the client. It also updates how table rows are keyed in the UI to avoid relying on internal IDs. These changes improve security by preventing exposure of sensitive internal fields and make the frontend code more robust.

**API response sanitization:**

* All inventory allocation and transaction API endpoints now strip internal fields (`id`, `tenantId`, `referenceId`) before sending data to the client, using mapping functions like `toSafeTransaction` and direct object destructuring. [[1]](diffhunk://#diff-8f83a886070fc296eb82536f8725b89b1956131bd912bf6ecd631259d7884a56L40-R40) [[2]](diffhunk://#diff-8f83a886070fc296eb82536f8725b89b1956131bd912bf6ecd631259d7884a56L55-R55) [[3]](diffhunk://#diff-52ad022f938b0de1ffb00f2b6669deb7c85afa6b21177920514907a409400352L6-R13) [[4]](diffhunk://#diff-52ad022f938b0de1ffb00f2b6669deb7c85afa6b21177920514907a409400352L35-R40) [[5]](diffhunk://#diff-52ad022f938b0de1ffb00f2b6669deb7c85afa6b21177920514907a409400352L44-R55) [[6]](diffhunk://#diff-52ad022f938b0de1ffb00f2b6669deb7c85afa6b21177920514907a409400352L88-R93)

* The shape of API responses for allocation-related actions (`consume`, `release`, `reserve`) has been updated to exclude allocation and transaction IDs. [[1]](diffhunk://#diff-5b55abb111bfa0aa7c949bcc2dcab3009c7bd2a8bd25511d778f198a9d95291cL52-L54) [[2]](diffhunk://#diff-3952d12b66d833a18aef9d1be6e8615be16f3ce290a96a33b2c1c26518addb48L55-L59) [[3]](diffhunk://#diff-d2be2463d82699af3c46a964a6af038f70351957d73beaa54ac1efeab9b26fc3L47-L48)

**Frontend type and rendering updates:**

* The frontend `SafeTransaction` type replaces the previous `InventoryTransaction` type, ensuring only client-safe fields are used.

* Table row keys in inventory and transaction UIs now use a combination of public fields (such as `itemId`, `createdAt`, and array index) instead of internal IDs, improving stability and privacy. [[1]](diffhunk://#diff-b2a3e38921f553b01f5dbc95f2f8c83fedf660bc0c1ea917591b0cbb995c8dd8L412-R410) [[2]](diffhunk://#diff-b2a3e38921f553b01f5dbc95f2f8c83fedf660bc0c1ea917591b0cbb995c8dd8L474-R472) [[3]](diffhunk://#diff-74d5458308225bc6dab25e8ef9746f9d186594f0ccca72e6d33fd17665aee3cdL68-R79)

**Type definitions:**

* Internal `id` fields have been removed from the `AllocationWithRelations` and `TransactionWithItem` interfaces to match the sanitized API responses. [[1]](diffhunk://#diff-b2a3e38921f553b01f5dbc95f2f8c83fedf660bc0c1ea917591b0cbb995c8dd8L34) [[2]](diffhunk://#diff-b2a3e38921f553b01f5dbc95f2f8c83fedf660bc0c1ea917591b0cbb995c8dd8L48-L54)