### PR TITLE
fix: remove redundant styling for tenant name display in JobInvoice component

### DIFF
--- a/src/components/tenant/jobs/job-invoice.tsx
+++ b/src/components/tenant/jobs/job-invoice.tsx
@@ -249,8 +249,8 @@ export function JobInvoice({
                   </div>
                   <div className="text-right">
                     {/* <h3 className="font-bold text-gray-900">{tenantDetails.name}</h3> */}
-                    <h3 className="font-bold text-red-600 text-xl">
-                      TENANT: {tenantDetails?.name}
+                    <h3 className="font-bold text-xl">
+                      {tenantDetails?.name}
                     </h3>
                     <p className="text-sm text-gray-600">
                       {tenantDetails.address}


### PR DESCRIPTION
This pull request makes a small UI adjustment to the `JobInvoice` component. The change removes the "TENANT:" label and the red color styling from the tenant's name, displaying it in the default font color and size.

* UI update in `job-invoice.tsx`: Removed the "TENANT:" prefix and red text color from the tenant's name, simplifying its display.